### PR TITLE
increase latency timeout

### DIFF
--- a/scripts/service_manager.py
+++ b/scripts/service_manager.py
@@ -112,7 +112,7 @@ class ServiceManager:
 
             # Poll until API is accessible or timeout
             print("⏳ Waiting for EverMemOS API to be ready...", end="", flush=True)
-            deadline = time.time() + 30
+            deadline = time.time() + 300
             while time.time() < deadline:
                 time.sleep(1)
                 print(".", end="", flush=True)
@@ -130,7 +130,7 @@ class ServiceManager:
                     return True
 
             print()
-            print("❌ Service did not become accessible within 30s")
+            print("❌ Service did not become accessible within 300s")
             print(f"   Check logs: cat {self.log_file}")
             return False
         else:

--- a/start_service.sh
+++ b/start_service.sh
@@ -130,7 +130,7 @@ fi
 # ── Step 2b: Wait for Docker services ready (MongoDB 27017 + Elasticsearch 19200) ─
 echo ""
 echo "  ⏳ Waiting for Docker services to be ready..."
-TIMEOUT=180  # 3 minutes max (ES cold-start after volume wipe can be slow)
+TIMEOUT=300  # 5 minutes max (ES cold-start after volume wipe can be slow; macOS Docker VM adds latency)
 ELAPSED=0
 
 while [ $ELAPSED -lt $TIMEOUT ]; do


### PR DESCRIPTION
MacOS's EverMemOS backend startup time is longer. Increase the waiting timeout.