### PR TITLE
fix problems

### DIFF
--- a/claude-skills/evermemos/scripts/evermemos_client.py
+++ b/claude-skills/evermemos/scripts/evermemos_client.py
@@ -34,6 +34,13 @@ class EverMemOSClient:
         self.user_id = user_id
         self.group_id = group_id
 
+    def _do_urlopen(self, req: urllib.request.Request, timeout: int, bypass_proxy: bool = False):
+        """Execute urlopen, optionally bypassing system proxy."""
+        if bypass_proxy:
+            opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+            return opener.open(req, timeout=timeout)
+        return urllib.request.urlopen(req, timeout=timeout)
+
     def _make_request(
         self,
         method: str,
@@ -41,7 +48,7 @@ class EverMemOSClient:
         data: Optional[Dict[str, Any]] = None,
         params: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
-        """Make HTTP request to EverMemOS API"""
+        """Make HTTP request to EverMemOS API, falling back to direct connection on proxy error."""
         url = f"{self.base_url}{endpoint}"
 
         # Add query parameters
@@ -57,18 +64,29 @@ class EverMemOSClient:
 
         req = urllib.request.Request(url, data=body, headers=headers, method=method)
 
-        try:
-            with urllib.request.urlopen(req, timeout=30) as response:
-                return json.loads(response.read().decode("utf-8"))
-        except urllib.error.HTTPError as e:
-            error_body = e.read().decode("utf-8") if e.fp else "No error details"
-            raise Exception(
-                f"HTTP {e.code} Error: {e.reason}\nDetails: {error_body}"
-            )
-        except urllib.error.URLError as e:
-            raise Exception(f"Connection Error: {e.reason}")
-        except Exception as e:
-            raise Exception(f"Request failed: {str(e)}")
+        proxy_configured = any(os.environ.get(k) for k in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"))
+
+        for bypass_proxy in (False, True):
+            try:
+                with self._do_urlopen(req, timeout=30, bypass_proxy=bypass_proxy) as response:
+                    return json.loads(response.read().decode("utf-8"))
+            except urllib.error.HTTPError as e:
+                error_body = e.read().decode("utf-8") if e.fp else "No error details"
+                # Proxy returned 502 — retry direct
+                if e.code == 502 and not bypass_proxy and proxy_configured:
+                    logger.warning(f"Proxy returned 502, retrying direct connection to {self.base_url}")
+                    continue
+                raise Exception(
+                    f"HTTP {e.code} Error: {e.reason}\nDetails: {error_body}"
+                )
+            except urllib.error.URLError as e:
+                # Proxy itself unreachable — retry direct
+                if not bypass_proxy and proxy_configured:
+                    logger.warning(f"Proxy connection failed ({e.reason}), retrying direct connection to {self.base_url}")
+                    continue
+                raise Exception(f"Connection Error: {e.reason}")
+            except Exception as e:
+                raise Exception(f"Request failed: {str(e)}")
 
     def search_memories(
         self,

--- a/claude-skills/evermemos/scripts/hook_session_end.py
+++ b/claude-skills/evermemos/scripts/hook_session_end.py
@@ -31,11 +31,28 @@ logger = get_logger("hook_session_end")
 
 def _is_service_available():
     base_url = os.environ.get('API_BASE_URL', 'http://localhost:1995')
-    try:
-        urllib.request.urlopen(f"{base_url}/health", timeout=10)
-        return True
-    except Exception:
-        return False
+    url = f"{base_url}/health"
+    proxy_configured = any(os.environ.get(k) for k in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'))
+
+    for bypass_proxy in (False, True):
+        try:
+            if bypass_proxy:
+                opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+                opener.open(url, timeout=10)
+            else:
+                urllib.request.urlopen(url, timeout=10)
+            return True
+        except urllib.error.HTTPError as e:
+            if e.code == 502 and not bypass_proxy and proxy_configured:
+                continue
+            return False
+        except urllib.error.URLError:
+            if not bypass_proxy and proxy_configured:
+                continue
+            return False
+        except Exception:
+            return False
+    return False
 
 
 def read_hook_input():

--- a/claude-skills/evermemos/scripts/hook_session_start.py
+++ b/claude-skills/evermemos/scripts/hook_session_start.py
@@ -34,11 +34,28 @@ logger = get_logger("hook_session_start")
 
 def _is_service_available():
     base_url = os.environ.get('API_BASE_URL', 'http://localhost:1995')
-    try:
-        urllib.request.urlopen(f"{base_url}/health", timeout=10)
-        return True
-    except Exception:
-        return False
+    url = f"{base_url}/health"
+    proxy_configured = any(os.environ.get(k) for k in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'))
+
+    for bypass_proxy in (False, True):
+        try:
+            if bypass_proxy:
+                opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+                opener.open(url, timeout=10)
+            else:
+                urllib.request.urlopen(url, timeout=10)
+            return True
+        except urllib.error.HTTPError as e:
+            if e.code == 502 and not bypass_proxy and proxy_configured:
+                continue
+            return False
+        except urllib.error.URLError:
+            if not bypass_proxy and proxy_configured:
+                continue
+            return False
+        except Exception:
+            return False
+    return False
 
 
 def get_env_config():

--- a/claude-skills/evermemos/scripts/hook_stop.py
+++ b/claude-skills/evermemos/scripts/hook_stop.py
@@ -31,11 +31,28 @@ logger = get_logger("hook_stop")
 
 def _is_service_available():
     base_url = os.environ.get('API_BASE_URL', 'http://localhost:1995')
-    try:
-        urllib.request.urlopen(f"{base_url}/health", timeout=10)
-        return True
-    except Exception:
-        return False
+    url = f"{base_url}/health"
+    proxy_configured = any(os.environ.get(k) for k in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'))
+
+    for bypass_proxy in (False, True):
+        try:
+            if bypass_proxy:
+                opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+                opener.open(url, timeout=10)
+            else:
+                urllib.request.urlopen(url, timeout=10)
+            return True
+        except urllib.error.HTTPError as e:
+            if e.code == 502 and not bypass_proxy and proxy_configured:
+                continue
+            return False
+        except urllib.error.URLError:
+            if not bypass_proxy and proxy_configured:
+                continue
+            return False
+        except Exception:
+            return False
+    return False
 
 
 def read_hook_input():

--- a/claude-skills/evermemos/scripts/hook_tool_use.py
+++ b/claude-skills/evermemos/scripts/hook_tool_use.py
@@ -31,11 +31,28 @@ logger = get_logger("hook_tool_use")
 
 def _is_service_available():
     base_url = os.environ.get('API_BASE_URL', 'http://localhost:1995')
-    try:
-        urllib.request.urlopen(f"{base_url}/health", timeout=10)
-        return True
-    except Exception:
-        return False
+    url = f"{base_url}/health"
+    proxy_configured = any(os.environ.get(k) for k in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'))
+
+    for bypass_proxy in (False, True):
+        try:
+            if bypass_proxy:
+                opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+                opener.open(url, timeout=10)
+            else:
+                urllib.request.urlopen(url, timeout=10)
+            return True
+        except urllib.error.HTTPError as e:
+            if e.code == 502 and not bypass_proxy and proxy_configured:
+                continue
+            return False
+        except urllib.error.URLError:
+            if not bypass_proxy and proxy_configured:
+                continue
+            return False
+        except Exception:
+            return False
+    return False
 
 
 def read_hook_input():

--- a/claude-skills/evermemos/scripts/hook_user_prompt.py
+++ b/claude-skills/evermemos/scripts/hook_user_prompt.py
@@ -30,11 +30,28 @@ logger = get_logger("hook_user_prompt")
 
 def _is_service_available():
     base_url = os.environ.get('API_BASE_URL', 'http://localhost:1995')
-    try:
-        urllib.request.urlopen(f"{base_url}/health", timeout=10)
-        return True
-    except Exception:
-        return False
+    url = f"{base_url}/health"
+    proxy_configured = any(os.environ.get(k) for k in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'))
+
+    for bypass_proxy in (False, True):
+        try:
+            if bypass_proxy:
+                opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+                opener.open(url, timeout=10)
+            else:
+                urllib.request.urlopen(url, timeout=10)
+            return True
+        except urllib.error.HTTPError as e:
+            if e.code == 502 and not bypass_proxy and proxy_configured:
+                continue
+            return False
+        except urllib.error.URLError:
+            if not bypass_proxy and proxy_configured:
+                continue
+            return False
+        except Exception:
+            return False
+    return False
 
 
 def read_hook_input():

--- a/scripts/remote_setup.py
+++ b/scripts/remote_setup.py
@@ -76,66 +76,78 @@ def main():
         _fail("ZEROG_WALLET_KEY is required for remote registration (used for 0G storage)")
         sys.exit(1)
 
-    # ── 2. Register with remote server (always, to get a fresh API key) ─────────
+    # ── 2. Register with remote server (skip if already registered) ──────────────
     secrets_path = project_dir / ".evermemos_remote_secrets"
 
-    _info(f"Registering user '{remote_user_id}' on {remote_url} ...")
+    existing_secrets = _read_kv_file(secrets_path)
+    existing_api_key = existing_secrets.get("EVERMEMOS_REMOTE_API_KEY", "")
+    existing_user_id = existing_secrets.get("MEMORY_USER_ID", "")
+    existing_remote_url = existing_secrets.get("MEMORY_REMOTE_URL", "")
 
-    register_url = f"{remote_url}/api/v1/users/register"
-    payload = json.dumps({
-        "user_id": remote_user_id,
-        "zerog_wallet_key": wallet_key,
-    }).encode("utf-8")
+    if (existing_api_key
+            and existing_user_id == remote_user_id
+            and (not existing_remote_url or existing_remote_url == remote_url)):
+        _info(f"User '{remote_user_id}' already registered on {remote_url} (credentials found in {secrets_path.name}), skipping registration.")
+        api_key = existing_api_key
+    else:
+        _info(f"Registering user '{remote_user_id}' on {remote_url} ...")
 
-    req = urllib.request.Request(
-        register_url,
-        data=payload,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
+        register_url = f"{remote_url}/api/v1/users/register"
+        payload = json.dumps({
+            "user_id": remote_user_id,
+            "zerog_wallet_key": wallet_key,
+        }).encode("utf-8")
 
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            raw = resp.read().decode("utf-8")
-            try:
-                body = json.loads(raw)
-            except json.JSONDecodeError:
-                _fail(
-                    f"Registration endpoint returned non-JSON response.\n"
-                    f"       Raw response: {raw[:200]}\n"
-                    f"       Check that {remote_url} is a valid EverMemOS server."
-                )
-                sys.exit(1)
-            api_key = body.get("api_key", "")
-            if not api_key:
-                _fail(
-                    f"Registration response did not contain an api_key.\n"
-                    f"       Response: {raw[:200]}"
-                )
-                sys.exit(1)
-    except urllib.error.HTTPError as e:
-        error_body = ""
-        if e.fp:
-            try:
-                error_body = e.read().decode("utf-8")
-            except Exception:
-                pass
-        _fail(f"Registration failed: HTTP {e.code} — {error_body}")
-        sys.exit(1)
-    except urllib.error.URLError as e:
-        _fail(
-            f"Cannot reach remote server at {remote_url}\n"
-            f"       Reason: {e.reason}\n"
-            f"       Check the URL and network connectivity."
+        req = urllib.request.Request(
+            register_url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
         )
-        sys.exit(1)
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                raw = resp.read().decode("utf-8")
+                try:
+                    body = json.loads(raw)
+                except json.JSONDecodeError:
+                    _fail(
+                        f"Registration endpoint returned non-JSON response.\n"
+                        f"       Raw response: {raw[:200]}\n"
+                        f"       Check that {remote_url} is a valid EverMemOS server."
+                    )
+                    sys.exit(1)
+                api_key = body.get("api_key", "")
+                if not api_key:
+                    _fail(
+                        f"Registration response did not contain an api_key.\n"
+                        f"       Response: {raw[:200]}"
+                    )
+                    sys.exit(1)
+        except urllib.error.HTTPError as e:
+            error_body = ""
+            if e.fp:
+                try:
+                    error_body = e.read().decode("utf-8")
+                except Exception:
+                    pass
+            _fail(f"Registration failed: HTTP {e.code} — {error_body}")
+            sys.exit(1)
+        except urllib.error.URLError as e:
+            _fail(
+                f"Cannot reach remote server at {remote_url}\n"
+                f"       Reason: {e.reason}\n"
+                f"       Check the URL and network connectivity."
+            )
+            sys.exit(1)
 
     # ── 3. Store credentials (overwrite) ─────────────────────────────────────
     _write_kv_file(secrets_path, {
         "MEMORY_USER_ID": remote_user_id,
+        "MEMORY_REMOTE_URL": remote_url,
         "EVERMEMOS_REMOTE_API_KEY": api_key,
     })
-    _ok(f"Registered successfully. Credentials saved to {secrets_path.name}")
+    _ok(f"Credentials saved to {secrets_path.name}")
 
     # ── 5. Update ~/.claude/settings.json ─────────────────────────────────────
     settings_path = Path.home() / ".claude" / "settings.json"

--- a/src/core/lifespan/data_sync_validation_listener.py
+++ b/src/core/lifespan/data_sync_validation_listener.py
@@ -95,6 +95,17 @@ class DataSyncValidationListener(AppReadyListener):
         doc_types = ["episodic_memory", "event_log", "foresight"]
         all_results = []
 
+        # kv_docs_by_collection is populated by MongoDB validation and used by Milvus/ES recovery.
+        # If Milvus or ES validation is enabled but MongoDB is not, force MongoDB on so that
+        # kv_docs_by_collection is always available (avoids falling back to DualStorageModelProxy
+        # reads that require a per-user KV context during startup).
+        if (check_milvus or check_es) and not check_mongodb:
+            logger.warning(
+                "STARTUP_SYNC_MONGODB=false but Milvus/ES validation is enabled — "
+                "forcing MongoDB validation on to populate kv_docs cache for recovery"
+            )
+            check_mongodb = True
+
         try:
             # STEP 0: Restore UserSecret table FIRST (prerequisite for everything else)
             # In server mode, UserSecret is needed to access any user's 0G stream
@@ -172,6 +183,10 @@ class DataSyncValidationListener(AppReadyListener):
 
         except Exception as e:
             logger.error("❌ Startup sync validation failed: %s", e, exc_info=True)
+            logger.error(
+                "⚠️  API gate will open but service may be degraded — "
+                "check logs above for root cause"
+            )
         finally:
             mark_ready()
             logger.info("✅ Startup recovery complete, API gate opened")
@@ -180,28 +195,22 @@ class DataSyncValidationListener(AppReadyListener):
         """
         Restore UserSecret table from local backup if needed.
         This must happen BEFORE any 0G stream access.
+        Raises on failure so the caller can log a degraded-service warning.
         """
         import os
 
-        try:
-            # Only do this in server mode
-            server_mode = os.getenv("SERVER_MODE", "false").lower() == "true"
-            if not server_mode:
-                logger.debug("Local mode detected, skipping UserSecret restore")
-                return
+        # Only do this in server mode
+        server_mode = os.getenv("SERVER_MODE", "false").lower() == "true"
+        if not server_mode:
+            logger.debug("Local mode detected, skipping UserSecret restore")
+            return
 
-            logger.info("🔑 Checking UserSecret table for server mode...")
+        logger.info("🔑 Checking UserSecret table for server mode...")
 
-            from infra_layer.adapters.out.persistence.user_secret_backup import UserSecretBackup
+        from infra_layer.adapters.out.persistence.user_secret_backup import UserSecretBackup
 
-            # Try to restore from backup.
-            # Returns True if backup file was found (KV scan can proceed).
-            # Returns False if backup file is missing (restore_to_mongodb already logged the reason).
-            await UserSecretBackup.restore_to_mongodb()
-
-        except Exception as e:
-            logger.error("❌ Failed to restore UserSecret table: %s", e)
-            # Don't crash startup if this fails - let the system try to continue
+        # Let any exception propagate — caller's finally block ensures mark_ready() runs.
+        await UserSecretBackup.restore_to_mongodb()
 
     def _log_result(self, result: SyncResult, days: int) -> None:
         """

--- a/src/infra_layer/adapters/input/api/user/user_controller.py
+++ b/src/infra_layer/adapters/input/api/user/user_controller.py
@@ -84,9 +84,13 @@ class UserController(BaseController):
         # Check for duplicate user_id
         existing = await UserSecret.find_one(UserSecret.user_id == body.user_id)
         if existing:
+            if existing.zerog_wallet_key == body.zerog_wallet_key:
+                # Same user re-registering (e.g. after uninstall) — return existing api_key
+                logger.info("User '%s' re-registered with matching wallet key, returning existing api_key", body.user_id)
+                return RegisterResponse(user_id=body.user_id, api_key=existing.api_key, message="Already registered.")
             raise HTTPException(
-                status_code=409,
-                detail=f"User '{body.user_id}' already exists.",
+                status_code=403,
+                detail=f"User '{body.user_id}' already exists with a different wallet key.",
             )
 
         # Generate credentials

--- a/src/infra_layer/adapters/out/persistence/kv_storage/user_aware_kv_storage.py
+++ b/src/infra_layer/adapters/out/persistence/kv_storage/user_aware_kv_storage.py
@@ -222,7 +222,7 @@ class UserAwareKVStorageProxy(KVStorageInterface):
 
         except Exception as e:
             logger.error("❌ Multi-user KV scan failed: %s", e)
-            # Don't raise - allow startup to continue even if scan fails
+            raise
 
     def close(self) -> None:
         for user_id, storage in self._cache.items():

--- a/src/infra_layer/adapters/out/persistence/user_secret_backup.py
+++ b/src/infra_layer/adapters/out/persistence/user_secret_backup.py
@@ -242,7 +242,7 @@ class UserSecretBackup:
 
         except Exception as e:
             logger.error("❌ Failed to restore users to MongoDB: %s", e)
-            return False
+            raise
 
     @staticmethod
     def _parse_datetime_safe(date_str: str):


### PR DESCRIPTION
## Description

  - Proxy fallback for client hooks — when a system proxy is configured and returns 502 or is unreachable, the client automatically retries with a direct connection, so Claude Code hooks work in corporate proxy environments
  - Idempotent re-registration — re-registering an existing user with the same wallet key now returns the existing api_key (200) instead of 409; different wallet key returns 403
  - Skip registration on re-install — remote_setup.py now checks for existing credentials and skips the registration API call if the user is already registered on the same server
  - KV scan failure now propagates — startup KV scan errors are no longer silently swallowed; they surface correctly so the validator can report data recovery failures
  - Force MongoDB on when Milvus/ES recovery is enabled — prevents a misconfiguration where STARTUP_SYNC_MONGODB=false would cause Milvus/ES recovery to fail due to missing document cache
  - UserSecret restore errors propagate to caller — startup no longer masks restore failures with a silent catch; degraded-service warning is logged and mark_ready() still runs via finally


## Related Issues

https://github.com/0gfoundation/0g-memory/issues/42