### PR TITLE
Gaoteng/install improve

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -225,11 +225,11 @@ else
         _SUDO=""
         command -v sudo &>/dev/null && _SUDO="sudo"
         if command -v apt-get &>/dev/null; then
-            $_SUDO apt-get install -y unzip
+            $_SUDO apt-get install -y unzip || { echo "  ❌ Failed to install unzip. Please install it manually and retry."; exit 1; }
         elif command -v yum &>/dev/null; then
-            $_SUDO yum install -y unzip
+            $_SUDO yum install -y unzip || { echo "  ❌ Failed to install unzip. Please install it manually and retry."; exit 1; }
         elif command -v brew &>/dev/null; then
-            brew install unzip
+            brew install unzip || { echo "  ❌ Failed to install unzip. Please install it manually and retry."; exit 1; }
         else
             echo "  ❌ Cannot install unzip automatically. Please install it manually and retry."
             exit 1

--- a/install.sh
+++ b/install.sh
@@ -221,8 +221,17 @@ else
     fi
 
     if ! command -v unzip &>/dev/null; then
-        echo "  ❌ unzip not found. Please install unzip and retry."
-        exit 1
+        echo "  ⚠️  unzip not found, attempting to install..."
+        if command -v apt-get &>/dev/null; then
+            sudo apt-get install -y unzip
+        elif command -v yum &>/dev/null; then
+            sudo yum install -y unzip
+        elif command -v brew &>/dev/null; then
+            brew install unzip
+        else
+            echo "  ❌ Cannot install unzip automatically. Please install it manually and retry."
+            exit 1
+        fi
     fi
 
     unzip -o "$ZGS_KV_ZIP" zgs_kv -d "$ZGS_KV_DIR"

--- a/install.sh
+++ b/install.sh
@@ -222,10 +222,12 @@ else
 
     if ! command -v unzip &>/dev/null; then
         echo "  ⚠️  unzip not found, attempting to install..."
+        _SUDO=""
+        command -v sudo &>/dev/null && _SUDO="sudo"
         if command -v apt-get &>/dev/null; then
-            sudo apt-get install -y unzip
+            $_SUDO apt-get install -y unzip
         elif command -v yum &>/dev/null; then
-            sudo yum install -y unzip
+            $_SUDO yum install -y unzip
         elif command -v brew &>/dev/null; then
             brew install unzip
         else

--- a/scripts/service_manager.py
+++ b/scripts/service_manager.py
@@ -31,20 +31,28 @@ class ServiceManager:
         self.log_file = existing_logs[-1] if existing_logs else logs_dir / "evermemos.log"
 
     def is_running(self) -> bool:
-        """Check if service is running"""
+        """Check if service is running by verifying both the PID and port 1995."""
         if not self.pid_file.exists():
             return False
 
         try:
             pid = int(self.pid_file.read_text().strip())
-            # Check if process exists
-            os.kill(pid, 0)
-            return True
+            os.kill(pid, 0)  # process exists
         except PermissionError:
-            # Process exists but owned by another user
-            return True
+            pass  # exists, owned by another user — fall through to port check
         except (ProcessLookupError, ValueError):
             # Process doesn't exist, clean up stale PID file
+            self.pid_file.unlink(missing_ok=True)
+            return False
+
+        # Process exists — also verify port 1995 is actually listening.
+        # A zombie or mis-matched PID can fool os.kill(pid, 0).
+        import socket
+        try:
+            with socket.create_connection(("localhost", 1995), timeout=2):
+                return True
+        except OSError:
+            # PID exists but port not open — stale PID file, clean up
             self.pid_file.unlink(missing_ok=True)
             return False
 

--- a/scripts/service_manager.py
+++ b/scripts/service_manager.py
@@ -30,51 +30,69 @@ class ServiceManager:
         existing_logs = sorted(logs_dir.glob("evermemos_*.log")) if logs_dir.exists() else []
         self.log_file = existing_logs[-1] if existing_logs else logs_dir / "evermemos.log"
 
-    def is_running(self) -> bool:
-        """Check if service is running by verifying both the PID and port 1995."""
-        if not self.pid_file.exists():
-            return False
-
+    def _is_process_alive(self, pid: int) -> bool:
+        """Return True if process with given PID exists (alive or zombie)."""
         try:
-            pid = int(self.pid_file.read_text().strip())
-            os.kill(pid, 0)  # process exists
+            os.kill(pid, 0)
+            return True
         except PermissionError:
-            pass  # exists, owned by another user — fall through to port check
-        except (ProcessLookupError, ValueError):
-            # Process doesn't exist, clean up stale PID file
-            self.pid_file.unlink(missing_ok=True)
+            return True  # exists, owned by another user
+        except (ProcessLookupError, ValueError, OSError):
             return False
 
-        # Process exists — also verify port 1995 is actually listening.
-        # A zombie or mis-matched PID can fool os.kill(pid, 0).
+    def _is_port_open(self) -> bool:
+        """Return True if port 1995 is accepting TCP connections."""
         import socket
         try:
             with socket.create_connection(("localhost", 1995), timeout=2):
                 return True
         except OSError:
-            # PID exists but port not open — stale PID file, clean up
+            return False
+
+    def is_running(self) -> bool:
+        """Return True if the service process is alive (PID file exists + process exists).
+
+        Does NOT check port 1995 — the process is considered 'running' as soon as it
+        is alive, even during the startup window before the API port opens.
+        Use _is_port_open() to check API readiness separately.
+        """
+        if not self.pid_file.exists():
+            return False
+
+        try:
+            pid = int(self.pid_file.read_text().strip())
+        except ValueError:
             self.pid_file.unlink(missing_ok=True)
             return False
 
+        if self._is_process_alive(pid):
+            return True
+
+        # Process is gone — clean up stale PID file
+        self.pid_file.unlink(missing_ok=True)
+        return False
+
     def get_status(self) -> Dict:
         """Get service status"""
+        process_alive = self.is_running()
         status = {
-            "running": self.is_running(),
+            "running": process_alive,
             "pid": None,
             "api_accessible": False,
             "mode": None
         }
 
-        if status["running"]:
+        if process_alive:
             status["pid"] = int(self.pid_file.read_text().strip())
 
-            # Check API health endpoint
-            try:
-                req = urllib.request.Request("http://localhost:1995/health")
-                with urllib.request.urlopen(req, timeout=2) as response:
-                    status["api_accessible"] = response.status == 200
-            except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
-                pass
+            # Check API health endpoint (only bother if port is open)
+            if self._is_port_open():
+                try:
+                    req = urllib.request.Request("http://localhost:1995/health")
+                    with urllib.request.urlopen(req, timeout=2) as response:
+                        status["api_accessible"] = response.status == 200
+                except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+                    pass
 
         # Check configuration file
         if (self.project_dir / ".env").exists():
@@ -129,24 +147,34 @@ class ServiceManager:
             # Save PID
             self.pid_file.write_text(str(process.pid))
 
-            # Poll until API is accessible or timeout
+            # Poll until API is accessible or timeout.
+            # Crash detection uses process.poll() — reliable because we hold the
+            # Popen object.  Readiness detection uses _is_port_open() + /health,
+            # kept separate so a slow startup never triggers a false "crashed" error.
             print("⏳ Waiting for EverMemOS API to be ready...", end="", flush=True)
             deadline = time.time() + 300
             while time.time() < deadline:
                 time.sleep(1)
                 print(".", end="", flush=True)
-                status = self.get_status()
-                if not status["running"]:
+                # Did the process exit?
+                if process.poll() is not None:
                     print()
                     print("❌ Service exited unexpectedly")
                     print(f"   Check logs: cat {self.log_file}")
                     return False
-                if status["api_accessible"]:
-                    print()
-                    print(f"✅ EverMemOS started successfully (PID: {process.pid})")
-                    print(f"📝 Logs: {self.log_file}")
-                    print(f"🌐 API: http://localhost:1995")
-                    return True
+                # Is the API ready?
+                if self._is_port_open():
+                    try:
+                        req = urllib.request.Request("http://localhost:1995/health")
+                        with urllib.request.urlopen(req, timeout=2) as response:
+                            if response.status == 200:
+                                print()
+                                print(f"✅ EverMemOS started successfully (PID: {process.pid})")
+                                print(f"📝 Logs: {self.log_file}")
+                                print(f"🌐 API: http://localhost:1995")
+                                return True
+                    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+                        pass
 
             print()
             print("❌ Service did not become accessible within 300s")

--- a/scripts/service_manager.py
+++ b/scripts/service_manager.py
@@ -91,7 +91,18 @@ class ServiceManager:
 
         # Always use .env
         env = os.environ.copy()
-        cmd = ["uv", "run", "python", "src/run.py", "--env-file", ".env"]
+        # Resolve uv absolute path — it may live in ~/.local/bin which is not
+        # always in PATH when the script is invoked non-interactively.
+        import shutil
+        uv_bin = (
+            shutil.which("uv", path=env.get("PATH", ""))
+            or shutil.which("uv", path=os.path.expanduser("~/.local/bin") + ":" + env.get("PATH", ""))
+        )
+        if not uv_bin:
+            raise FileNotFoundError(
+                "uv not found. Add ~/.local/bin to PATH or reinstall uv: curl -LsSf https://astral.sh/uv/install.sh | sh"
+            )
+        cmd = [uv_bin, "run", "python", "src/run.py", "--env-file", ".env"]
 
         if background:
             print("🚀 Starting EverMemOS in background...")

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -33,6 +33,8 @@ class SetupManager:
     def __init__(self, project_dir: Optional[str] = None):
         self.project_dir = Path(project_dir) if project_dir else Path.cwd()
         self.os_type = platform.system().lower()
+        # Use sudo only when it is available (not present on root-only envs like TEE containers)
+        self._sudo = "sudo " if shutil.which("sudo") else ""
 
     def _read_env_value(self, key: str, default: str = "") -> str:
         """Read a single key from .env file. Returns default if file or key not found."""
@@ -218,19 +220,19 @@ class SetupManager:
 
                 commands = [
                     # Update package index
-                    "sudo apt-get update",
+                    f"{self._sudo}apt-get update",
                     # Install prerequisites
-                    "sudo apt-get install -y ca-certificates curl gnupg",
+                    f"{self._sudo}apt-get install -y ca-certificates curl gnupg",
                     # Add Docker's official GPG key
-                    "sudo install -m 0755 -d /etc/apt/keyrings",
-                    "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg",
-                    "sudo chmod a+r /etc/apt/keyrings/docker.gpg",
+                    f"{self._sudo}install -m 0755 -d /etc/apt/keyrings",
+                    f"curl -fsSL https://download.docker.com/linux/ubuntu/gpg | {self._sudo}gpg --dearmor -o /etc/apt/keyrings/docker.gpg",
+                    f"{self._sudo}chmod a+r /etc/apt/keyrings/docker.gpg",
                     # Set up repository
-                    'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null',
+                    f'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | {self._sudo}tee /etc/apt/sources.list.d/docker.list > /dev/null',
                     # Update package index again
-                    "sudo apt-get update",
+                    f"{self._sudo}apt-get update",
                     # Install Docker
-                    "sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin",
+                    f"{self._sudo}apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin",
                 ]
 
                 for cmd in commands:
@@ -244,14 +246,14 @@ class SetupManager:
                     )
 
                 # Start Docker service
-                subprocess.run("sudo systemctl start docker", shell=True, check=True)
-                subprocess.run("sudo systemctl enable docker", shell=True, check=True)
+                subprocess.run(f"{self._sudo}systemctl start docker", shell=True, check=True)
+                subprocess.run(f"{self._sudo}systemctl enable docker", shell=True, check=True)
 
                 # Add current user to docker group (optional, requires re-login)
                 try:
                     username = os.environ.get("USER", os.environ.get("USERNAME"))
                     if username:
-                        subprocess.run(f"sudo usermod -aG docker {username}", shell=True, check=True)
+                        subprocess.run(f"{self._sudo}usermod -aG docker {username}", shell=True, check=True)
                         self.print_warning(f"Added {username} to docker group")
                         self.print_warning("You may need to log out and back in for group changes to take effect")
                 except:
@@ -264,11 +266,11 @@ class SetupManager:
                 self.print_info("Installing Docker on RHEL/CentOS/Fedora...")
 
                 commands = [
-                    "sudo yum install -y yum-utils",
-                    "sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo",
-                    "sudo yum install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin",
-                    "sudo systemctl start docker",
-                    "sudo systemctl enable docker",
+                    f"{self._sudo}yum install -y yum-utils",
+                    f"{self._sudo}yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo",
+                    f"{self._sudo}yum install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin",
+                    f"{self._sudo}systemctl start docker",
+                    f"{self._sudo}systemctl enable docker",
                 ]
 
                 for cmd in commands:
@@ -386,8 +388,8 @@ class SetupManager:
                 self.print_info("Installing Docker Compose plugin on Debian/Ubuntu...")
 
                 commands = [
-                    "sudo apt-get update",
-                    "sudo apt-get install -y docker-compose-plugin",
+                    f"{self._sudo}apt-get update",
+                    f"{self._sudo}apt-get install -y docker-compose-plugin",
                 ]
 
                 for cmd in commands:
@@ -407,7 +409,7 @@ class SetupManager:
                 self.print_info("Installing Docker Compose plugin on RHEL/CentOS/Fedora...")
 
                 commands = [
-                    "sudo yum install -y docker-compose-plugin",
+                    f"{self._sudo}yum install -y docker-compose-plugin",
                 ]
 
                 for cmd in commands:

--- a/start_service.sh
+++ b/start_service.sh
@@ -14,6 +14,9 @@
 
 set -e
 
+# ── Ensure ~/.local/bin is in PATH (uv installs there) ───────────────────────
+export PATH="$HOME/.local/bin:$PATH"
+
 # ── Parse arguments ───────────────────────────────────────────────────────────
 RESTART=false
 for arg in "$@"; do
@@ -183,7 +186,7 @@ while [ $ELAPSED -lt $TIMEOUT ]; do
     MONGO_OK=false
     ES_OK=false
 
-    nc -z localhost 27017 2>/dev/null && MONGO_OK=true || true
+    (echo > /dev/tcp/localhost/27017) 2>/dev/null && MONGO_OK=true || true
     # Use ES cluster health API instead of TCP check: port open ≠ ES ready.
     # wait_for_status=yellow ensures all primary shards are allocated before returning.
     # Must check "timed_out":false in the response body — ES always returns HTTP 200

--- a/start_service.sh
+++ b/start_service.sh
@@ -96,7 +96,10 @@ KV_TS=$(date -u +"%Y%m%d_%H%M%S")
 KV_LOG="$KV_RUN_DIR/kv_${KV_TS}.log"
 KV_STARTED=false
 
-if pgrep -f "zgs_kv" > /dev/null 2>&1; then
+KV_PORT_OPEN=false
+(echo > /dev/tcp/localhost/6789) 2>/dev/null && KV_PORT_OPEN=true || true
+
+if pgrep -f "zgs_kv" > /dev/null 2>&1 && [ "$KV_PORT_OPEN" = true ]; then
     echo "  ✅ kv-server already running, skipping"
 elif [ ! -f "$KV_BIN" ]; then
     echo "  ⚠️  kv-server binary not found at $KV_BIN, skipping"


### PR DESCRIPTION
## Description

  - install.sh: auto-install unzip via apt-get/yum/brew when missing, with || exit 1 on failure; skip sudo
  when not available
  - scripts/setup.py: make all Docker install commands sudo-optional (self._sudo = "sudo " if
  shutil.which("sudo") else "")
  - start_service.sh:
    - prepend ~/.local/bin to PATH so uv is found in non-interactive shells
    - replace nc -z with /dev/tcp bash built-in (nc not installed on minimal Ubuntu)
    - require both pgrep and port 6789 open before declaring kv-server already running
  - scripts/service_manager.py:
    - resolve uv absolute path via shutil.which with ~/.local/bin fallback
    - split is_running() (process-alive only) from _is_port_open() (TCP check); add _is_process_alive(pid)
  helper
    - fix false "Service exited unexpectedly" during slow startup: polling loop now uses process.poll() for
  crash detection and _is_port_open() + /health for readiness, keeping the two concerns independent

## Related Issues

https://github.com/0gfoundation/0g-memory/issues/22