### PR TITLE
force asyncio event loop to prevent GPF crashes

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -137,7 +137,7 @@ def main():
 
     # Start service using command line arguments
     try:
-        uvicorn_kwargs = {"host": host, "port": port}
+        uvicorn_kwargs = {"host": host, "port": port, "loop": "asyncio"}
         uvicorn.run(app, **uvicorn_kwargs)
     except KeyboardInterrupt:
         logger.info("👋 %s stopped", APP_NAME)


### PR DESCRIPTION
Several middlewares still use BaseHTTPMiddleware, which triggers a known uvloop + Python 3.12 bug: abandoned async generator streams are finalized on GC, gradually corrupting the event loop and causing a General Protection Fault that kills the process. Setting loop="asyncio" in uvicorn.run() disables uvloop as a temporary mitigation until the remaining middlewares are migrated to pure ASGI.